### PR TITLE
Change update API and add observers

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ certStore.update(updateMode, updateObserver)
 The method is asynchronous.
 
 `UpdateObserver` has two callbacks:
-- `onUpdateInitiated(UpdateType)` tells you what type of update has been started
+- `onUpdateStarted(UpdateType)` tells you what type of update has been started
 - `onUpdateFinished(UpdateResult)` tells you the result fo the update
 
 Both callbacks are notified on the main thread.
@@ -205,7 +205,7 @@ if not defined, the update run on a dedicated thread.
 Note that the app is responsible for invoking update method.
 The app has to typically call the update during the application's startup,
 before a secure HTTPS request is initiated to a server that's supposed to be validated with the pinning.
-If the update type is **not** `UpdateType.DIRECT` the app can resume work right after `onUpdateInitiated()`
+If the update type is **not** `UpdateType.DIRECT` the app can resume work right after `onUpdateStarted()`
 is called.
 
 The update function works in two basic modes:

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The method is asynchronous.
 
 `UpdateObserver` has two callbacks:
 - `onUpdateStarted(UpdateType)` tells you what type of update has been started
-- `onUpdateFinished(UpdateResult)` tells you the result fo the update
+- `onUpdateFinished(UpdateType, UpdateResult)` tells you the result and type of the update
 
 Both callbacks are notified on the main thread.
 
@@ -193,6 +193,10 @@ of failing network requests due to server certificates evaluated as untrusted.
 - `UpdateType.NO_UPDATE` - No update will be performed. The library
 has data and they are not going to expire soon. There's low risk
 of failing network requests due to server certificates evaluated as untrusted.
+
+To simplify integration, the library offers `DefaultUpdateObserver`
+that offers abstract method `continueExecution()` that will be called
+when it's recommended to continue execution based on the evaluated `UpdateType`.
 
 Note that in any update type there's still risk of failing network requests
 due to server certificates evaluated as untrusted. This is due to the fact

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     - [Configuration](#configuration)
     - [Update fingerprints](#updating-fingerprints)
     - [Fingerprint validation](#fingerprint-validation)
+        - [Global validation observers](#global-validation-observers)
     - [PowerAuth integration](#powerauth-integration)
     - [PowerAuth integration from Java](#powerauth-integration-from-java)
     - [Integration](#integration)
@@ -255,6 +256,18 @@ if (validationResult != ValidationResult.TRUSTED) {
     throw javax.net.ssl.SSLException()
 }
 ```
+
+### Global validation observers
+
+In order to be notified about all validation failures there is `ValidationObserver`
+interface and methods on `CertStore` for adding/removing global validation observers.
+
+Motivation for these global validation observers is that some validation failures
+(e.g. those happening in `SSLSocketFactory` instances created by `SSLSocketIntegration.createSSLPinningSocketFactory(CertStore)`)
+are out of reach of the app integrating the pinning library.
+These global validation observers are notified about all such validation failures.
+The app can then react with force updating the fingerprints.
+
 
 ## PowerAuth integration
 

--- a/library/src/androidTest/java/com/wultra/android/sslpinning/CertStoreUpdateTest.kt
+++ b/library/src/androidTest/java/com/wultra/android/sslpinning/CertStoreUpdateTest.kt
@@ -22,7 +22,6 @@ import android.util.Base64
 import com.wultra.android.sslpinning.integration.powerauth.PowerAuthCryptoProvider
 import com.wultra.android.sslpinning.integration.powerauth.PowerAuthSecureDataStore
 import com.wultra.android.sslpinning.integration.powerauth.powerAuthCertStore
-import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -41,8 +40,7 @@ class CertStoreUpdateTest {
         val config = CertStoreConfiguration.Builder(url, getPublicKeyBytes()).build()
         val store = CertStore(config, PowerAuthCryptoProvider(), PowerAuthSecureDataStore(appContext), remoteDataProvider)
 
-        val updateResult = store.update(UpdateMode.FORCED)
-        assertEquals(UpdateResult.OK, updateResult)
+        updateAndCheck(store, UpdateMode.FORCED, UpdateResult.OK)
     }
 
     @Test
@@ -52,8 +50,7 @@ class CertStoreUpdateTest {
         val config = CertStoreConfiguration.Builder(url, getPublicKeyBytes()).build()
         val store = CertStore.powerAuthCertStore(config, appContext)
 
-        val updateResult = store.update(UpdateMode.FORCED)
-        assertEquals(UpdateResult.OK, updateResult)
+        updateAndCheck(store, UpdateMode.FORCED, UpdateResult.OK)
     }
 
     @Test
@@ -67,7 +64,6 @@ class CertStoreUpdateTest {
         val config = CertStoreConfiguration.Builder(url, publicKeyBytes).build()
         val store = CertStore.powerAuthCertStore(config, appContext)
 
-        val updateResult = store.update(UpdateMode.FORCED)
-        assertEquals(UpdateResult.INVALID_SIGNATURE, updateResult)
+        updateAndCheck(store, UpdateMode.FORCED, UpdateResult.INVALID_SIGNATURE)
     }
 }

--- a/library/src/androidTest/java/com/wultra/android/sslpinning/CertStoreUpdateTestJava.java
+++ b/library/src/androidTest/java/com/wultra/android/sslpinning/CertStoreUpdateTestJava.java
@@ -31,7 +31,7 @@ import static com.wultra.android.sslpinning.TestUtilsKt.getJsonDataAllEmpty;
 import static com.wultra.android.sslpinning.TestUtilsKt.getJsonDataFingerprintsEmpty;
 import static com.wultra.android.sslpinning.TestUtilsKt.getPublicKeyBytes;
 import static com.wultra.android.sslpinning.TestUtilsKt.getRemoteDataProvider;
-import static org.junit.Assert.assertEquals;
+import static com.wultra.android.sslpinning.TestUtilsKt.updateAndCheck;
 
 /**
  * Instrumentation test for update signature validation on a device/emulator.
@@ -51,8 +51,7 @@ public class CertStoreUpdateTestJava {
         CertStoreConfiguration config = new CertStoreConfiguration.Builder(url, getPublicKeyBytes()).build();
         CertStore store = PowerAuthCertStore.createInstance(config, appContext);
 
-        UpdateResult updateResult = store.update(UpdateMode.FORCED);
-        assertEquals(UpdateResult.NETWORK_ERROR, updateResult);
+        updateAndCheck(store, UpdateMode.FORCED, UpdateResult.NETWORK_ERROR);
     }
 
     @Test
@@ -64,8 +63,7 @@ public class CertStoreUpdateTestJava {
         CertStoreConfiguration config = new CertStoreConfiguration.Builder(url, getPublicKeyBytes()).build();
         CertStore store = new CertStore(config, new PowerAuthCryptoProvider(), new PowerAuthSecureDataStore(appContext), getRemoteDataProvider(getJsonDataAllEmpty()));
 
-        UpdateResult updateResult = store.update(UpdateMode.FORCED);
-        assertEquals(UpdateResult.INVALID_DATA, updateResult);
+        updateAndCheck(store, UpdateMode.FORCED, UpdateResult.INVALID_DATA);
     }
 
     @Test
@@ -77,8 +75,7 @@ public class CertStoreUpdateTestJava {
         CertStoreConfiguration config = new CertStoreConfiguration.Builder(url, getPublicKeyBytes()).build();
         CertStore store = new CertStore(config, new PowerAuthCryptoProvider(), new PowerAuthSecureDataStore(appContext), getRemoteDataProvider(getJsonDataFingerprintsEmpty()));
 
-        UpdateResult updateResult = store.update(UpdateMode.FORCED);
-        assertEquals(UpdateResult.STORE_IS_EMPTY, updateResult);
+        updateAndCheck(store, UpdateMode.FORCED, UpdateResult.STORE_IS_EMPTY);
     }
 
     @Test
@@ -90,7 +87,6 @@ public class CertStoreUpdateTestJava {
         CertStoreConfiguration config = new CertStoreConfiguration.Builder(url, getPublicKeyBytes()).build();
         CertStore store = PowerAuthCertStore.createInstance(config, appContext);
 
-        UpdateResult updateResult = store.update(UpdateMode.FORCED);
-        assertEquals(UpdateResult.STORE_IS_EMPTY, updateResult);
+        updateAndCheck(store, UpdateMode.FORCED, UpdateResult.STORE_IS_EMPTY);
     }
 }

--- a/library/src/androidTest/java/com/wultra/android/sslpinning/CertStoreValidateTest.kt
+++ b/library/src/androidTest/java/com/wultra/android/sslpinning/CertStoreValidateTest.kt
@@ -54,8 +54,7 @@ class CertStoreValidateTest {
         val config = CertStoreConfiguration.Builder(url, getPublicKeyBytes())
                 .build()
         val store = CertStore.powerAuthCertStore(config, appContext)
-        val updateResult = store.update(UpdateMode.FORCED)
-        Assert.assertEquals(UpdateResult.OK, updateResult)
+        updateAndCheck(store, UpdateMode.FORCED, UpdateResult.OK)
 
         val cert = getCertificateFromUrl("https://github.com")
         val result = store.validateCertificate(cert)

--- a/library/src/androidTest/java/com/wultra/android/sslpinning/TestUtils.kt
+++ b/library/src/androidTest/java/com/wultra/android/sslpinning/TestUtils.kt
@@ -92,7 +92,7 @@ fun updateAndCheck(store: CertStore, updateMode: UpdateMode, expectedUpdateResul
     val latch = CountDownLatch(1)
     val updateResultWrapper = UpdateWrapper()
     val updateStarted = store.update(updateMode, object : UpdateObserver {
-        override fun onUpdateInitiated(type: UpdateType) {
+        override fun onUpdateStarted(type: UpdateType) {
             updateResultWrapper.updateType = type
             initLatch.countDown();
         }

--- a/library/src/androidTest/java/com/wultra/android/sslpinning/TestUtils.kt
+++ b/library/src/androidTest/java/com/wultra/android/sslpinning/TestUtils.kt
@@ -97,7 +97,7 @@ fun updateAndCheck(store: CertStore, updateMode: UpdateMode, expectedUpdateResul
             initLatch.countDown();
         }
 
-        override fun onUpdateFinished(result: UpdateResult) {
+        override fun onUpdateFinished(type: UpdateType, result: UpdateResult) {
             updateResultWrapper.updateResult = result
             latch.countDown()
         }

--- a/library/src/androidTest/java/com/wultra/android/sslpinning/UpdateResultWrapper.kt
+++ b/library/src/androidTest/java/com/wultra/android/sslpinning/UpdateResultWrapper.kt
@@ -17,30 +17,8 @@
 package com.wultra.android.sslpinning
 
 /**
- * Result of update request.
+ * Helper wrapper for passing update result outside of callbacks.
  *
  * @author Tomas Kypta, tomas.kypta@wultra.com
  */
-enum class UpdateResult {
-    /**
-     * Update succeeded. Everything is ok.
-     */
-    OK,
-    /**
-     * [CertStore] is empty. There's no valid certificate fingeprint to validate server cert against.
-     * Might happen when all the certificate fingerprints are already expired.
-     */
-    STORE_IS_EMPTY,
-    /**
-     * There was an error in network communication with the server.
-     */
-    NETWORK_ERROR,
-    /**
-     * The update request returned invalid data from the server.
-     */
-    INVALID_DATA,
-    /**
-     * The update request returned data which did not pass the signature validation.
-     */
-    INVALID_SIGNATURE
-}
+data class UpdateResultWrapper(var updateResult: UpdateResult? = null)

--- a/library/src/androidTest/java/com/wultra/android/sslpinning/UpdateWrapper.kt
+++ b/library/src/androidTest/java/com/wultra/android/sslpinning/UpdateWrapper.kt
@@ -17,8 +17,9 @@
 package com.wultra.android.sslpinning
 
 /**
- * Helper wrapper for passing update result outside of callbacks.
+ * Helper wrapper for passing update type and result outside of callbacks.
  *
  * @author Tomas Kypta, tomas.kypta@wultra.com
  */
-data class UpdateResultWrapper(var updateResult: UpdateResult? = null)
+data class UpdateWrapper(var updateResult: UpdateResult? = null,
+                         var updateType: UpdateType? = null)

--- a/library/src/androidTest/java/com/wultra/android/sslpinning/integration/SSLPinningIntegrationTest.kt
+++ b/library/src/androidTest/java/com/wultra/android/sslpinning/integration/SSLPinningIntegrationTest.kt
@@ -45,8 +45,7 @@ class SSLPinningIntegrationTest {
         val config = CertStoreConfiguration.Builder(url, getPublicKeyBytes())
                 .build()
         val store = CertStore.powerAuthCertStore(config, appContext)
-        val updateResult = store.update(UpdateMode.FORCED)
-        Assert.assertEquals(UpdateResult.OK, updateResult)
+        updateAndCheck(store, UpdateMode.FORCED, UpdateResult.OK)
 
         val url = URL("https://github.com")
 
@@ -70,8 +69,7 @@ class SSLPinningIntegrationTest {
         val config = CertStoreConfiguration.Builder(url, getPublicKeyBytes())
                 .build()
         val store = CertStore.powerAuthCertStore(config, appContext)
-        val updateResult = store.update(UpdateMode.FORCED)
-        Assert.assertEquals(UpdateResult.OK, updateResult)
+        updateAndCheck(store, UpdateMode.FORCED, UpdateResult.OK)
 
         val url = URL("https://google.com")
 
@@ -95,8 +93,7 @@ class SSLPinningIntegrationTest {
         val config = CertStoreConfiguration.Builder(url, getPublicKeyBytes())
                 .build()
         val store = CertStore.powerAuthCertStore(config, appContext)
-        val updateResult = store.update(UpdateMode.FORCED)
-        Assert.assertEquals(UpdateResult.OK, updateResult)
+        updateAndCheck(store, UpdateMode.FORCED, UpdateResult.OK)
 
         val url = URL("https://github.com")
 
@@ -125,8 +122,7 @@ class SSLPinningIntegrationTest {
         val config = CertStoreConfiguration.Builder(url, getPublicKeyBytes())
                 .build()
         val store = CertStore.powerAuthCertStore(config, appContext)
-        val updateResult = store.update(UpdateMode.FORCED)
-        Assert.assertEquals(UpdateResult.OK, updateResult)
+        updateAndCheck(store, UpdateMode.FORCED, UpdateResult.OK)
 
         val url = URL("https://google.com")
 

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -14,5 +14,4 @@
   ~ and limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.wultra.android.sslpinning" />
+<manifest package="com.wultra.android.sslpinning" />

--- a/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
@@ -39,7 +39,7 @@ import java.security.cert.X509Certificate
 import java.util.*
 
 /**
- * The main class that provides features of the dynamic SSL pinng library.
+ * The main class that provides features of the dynamic SSL pinning library.
  *
  * @author Tomas Kypta, tomas.kypta@wultra.com
  */
@@ -93,7 +93,7 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
      */
     @Synchronized
     fun reset() {
-        WultraDebug.warning("CertStore: reset() hould not be used in production build.")
+        WultraDebug.warning("CertStore: reset() should not be used in production build.")
         cachedData = null
         secureDataStore.remove(key = instanceIdentifier)
     }
@@ -320,7 +320,7 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
 
                 configuration.expectedCommonNames?.let { expectedCN ->
                     if (!expectedCN.contains(newCertificateInfo.commonName)) {
-                        // CertStore will stor ethis CertificateInfo, but validation will ignore
+                        // CertStore will store this CertificateInfo, but validation will ignore
                         // this entry because it's not in expectedCommonNames
                         WultraDebug.warning("CertStore: Loaded data contains name, which will not be trusted. CN = '${entry.name}'")
                     }

--- a/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
@@ -171,15 +171,15 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
      *
      * The method checks if the update is necessary based on the stored data and update mode.
      * It internally computes [UpdateType] as in [getUpdateType] method.
-     * The observer returns [UpdateType] in [UpdateObserver.onUpdateInitiated] method after
+     * The observer returns [UpdateType] in [UpdateObserver.onUpdateStarted] method after
      * the method is called. And [UpdateObserver.onUpdateFinished] with [UpdateResult]
      * is called after update was performed.
      *
      * If the method decides update is not necessary ([UpdateType.NO_UPDATE]),
      * it will not start the update and [UpdateObserver.onUpdateFinished] is called after
-     * [UpdateObserver.onUpdateInitiated].
+     * [UpdateObserver.onUpdateStarted].
      *
-     * In every case both callbacks [UpdateObserver.onUpdateInitiated]
+     * In every case both callbacks [UpdateObserver.onUpdateStarted]
      * and [UpdateObserver.onUpdateFinished] are always called.
      *
      * The update is scheduled either on an [java.util.concurrent.ExecutorService] provided in the configuration
@@ -200,7 +200,7 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
         }
 
         mainThreadHandler.post {
-            updateObserver.onUpdateInitiated(updateType)
+            updateObserver.onUpdateStarted(updateType)
         }
 
         if (!updateType.isPerformingUpdate) {

--- a/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
@@ -205,10 +205,10 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
 
         if (!updateType.isPerformingUpdate) {
             mainThreadHandler.post {
-                updateObserver.onUpdateFinished(UpdateResult.OK)
+                updateObserver.onUpdateFinished(updateType, UpdateResult.OK)
             }
         } else {
-            doUpdateAsync(now, updateObserver)
+            doUpdateAsync(now, updateType, updateObserver)
         }
     }
 
@@ -246,11 +246,11 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
         return processReceivedData(bytes, currentDate)
     }
 
-    private fun doUpdateAsync(currentDate: Date, updateObserver: UpdateObserver) {
+    private fun doUpdateAsync(currentDate: Date, updateType: UpdateType, updateObserver: UpdateObserver) {
         val updateRunnable = Runnable {
             val result = doUpdate(currentDate)
             mainThreadHandler.post {
-                updateObserver.onUpdateFinished(result)
+                updateObserver.onUpdateFinished(updateType, result)
             }
         }
 

--- a/library/src/main/java/com/wultra/android/sslpinning/CertStoreConfiguration.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/CertStoreConfiguration.kt
@@ -205,7 +205,7 @@ class CertStoreConfiguration(
         }
 
         /**
-         * Executor service for performing silend updates of certificate fingerprints.
+         * Executor service for performing silent updates of certificate fingerprints.
          */
         fun executorService(executorService: ExecutorService?) = apply {
             this.executorService = executorService

--- a/library/src/main/java/com/wultra/android/sslpinning/UpdateObserver.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/UpdateObserver.kt
@@ -16,9 +16,13 @@
 
 package com.wultra.android.sslpinning
 
+import android.support.annotation.MainThread
+
 /**
- * Observer for receiving update rusults from asynchronous
+ * Observer for receiving update results from asynchronous
  * [CertStore.update] method.
+ *
+ * Callbacks are executed on the main thread.
  *
  * @author Tomas Kypta, tomas.kypta@wultra.com
  *
@@ -27,9 +31,20 @@ package com.wultra.android.sslpinning
 interface UpdateObserver {
 
     /**
+     * Called when an update is initiated and [UpdateType] is evaluated.
+     *
+     * @param type Type of updated that was selected based on the input parameters and stored data.
+     */
+    @MainThread
+    fun onUpdateInitiated(type: UpdateType)
+
+    /**
      * Called when an update finishes.
+     *
+     * In case of [UpdateType.NO_UPDATE], it's called immediately after [onUpdateInitiated].
      *
      * @param result Result of the update.
      */
+    @MainThread
     fun onUpdateFinished(result: UpdateResult)
 }

--- a/library/src/main/java/com/wultra/android/sslpinning/UpdateObserver.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/UpdateObserver.kt
@@ -17,30 +17,19 @@
 package com.wultra.android.sslpinning
 
 /**
- * Result of update request.
+ * Observer for receiving update rusults from asynchronous
+ * [CertStore.update] method.
  *
  * @author Tomas Kypta, tomas.kypta@wultra.com
+ *
+ * @since 0.9.0
  */
-enum class UpdateResult {
+interface UpdateObserver {
+
     /**
-     * Update succeeded. Everything is ok.
+     * Called when an update finishes.
+     *
+     * @param result Result of the update.
      */
-    OK,
-    /**
-     * [CertStore] is empty. There's no valid certificate fingeprint to validate server cert against.
-     * Might happen when all the certificate fingerprints are already expired.
-     */
-    STORE_IS_EMPTY,
-    /**
-     * There was an error in network communication with the server.
-     */
-    NETWORK_ERROR,
-    /**
-     * The update request returned invalid data from the server.
-     */
-    INVALID_DATA,
-    /**
-     * The update request returned data which did not pass the signature validation.
-     */
-    INVALID_SIGNATURE
+    fun onUpdateFinished(result: UpdateResult)
 }

--- a/library/src/main/java/com/wultra/android/sslpinning/UpdateObserver.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/UpdateObserver.kt
@@ -31,17 +31,17 @@ import android.support.annotation.MainThread
 interface UpdateObserver {
 
     /**
-     * Called when an update is initiated and [UpdateType] is evaluated.
+     * Called when an update has been started and [UpdateType] has been evaluated.
      *
      * @param type Type of updated that was selected based on the input parameters and stored data.
      */
     @MainThread
-    fun onUpdateInitiated(type: UpdateType)
+    fun onUpdateStarted(type: UpdateType)
 
     /**
      * Called when an update finishes.
      *
-     * In case of [UpdateType.NO_UPDATE], it's called immediately after [onUpdateInitiated].
+     * In case of [UpdateType.NO_UPDATE], it's called immediately after [onUpdateStarted].
      *
      * @param result Result of the update.
      */

--- a/library/src/main/java/com/wultra/android/sslpinning/UpdateObserver.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/UpdateObserver.kt
@@ -33,7 +33,7 @@ interface UpdateObserver {
     /**
      * Called when an update has been started and [UpdateType] has been evaluated.
      *
-     * @param type Type of updated that was selected based on the input parameters and stored data.
+     * @param type Type of update that was selected based on the input parameters and stored data.
      */
     @MainThread
     fun onUpdateStarted(type: UpdateType)
@@ -43,8 +43,9 @@ interface UpdateObserver {
      *
      * In case of [UpdateType.NO_UPDATE], it's called immediately after [onUpdateStarted].
      *
+     * @param type Type of update
      * @param result Result of the update.
      */
     @MainThread
-    fun onUpdateFinished(result: UpdateResult)
+    fun onUpdateFinished(type: UpdateType, result: UpdateResult)
 }

--- a/library/src/main/java/com/wultra/android/sslpinning/UpdateResult.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/UpdateResult.kt
@@ -27,7 +27,7 @@ enum class UpdateResult {
      */
     OK,
     /**
-     * [CertStore] is empty. There's no valid certificate fingeprint to validate server cert against.
+     * [CertStore] is empty. There's no valid certificate fingerprint to validate server cert against.
      * Might happen when all the certificate fingerprints are already expired.
      */
     STORE_IS_EMPTY,

--- a/library/src/main/java/com/wultra/android/sslpinning/UpdateType.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/UpdateType.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.wultra.android.sslpinning
+
+/**
+ * Type of update initiated by [CertStore.update] method.
+ *
+ * @author Tomas Kypta, tomas.kypta@wultra.com
+ *
+ * @since 0.9.0
+ */
+enum class UpdateType {
+
+    /**
+     * The update is direct.
+     *
+     * App should wait for the update to finish because it means there is some serious problem
+     * with current fingerprint data. Network requests (SSL handshakes) might fail.
+     */
+    DIRECT,
+
+    /**
+     * The update is silent.
+     *
+     * App can continue normally. But it's time to check for updates.
+     * It's improbable that network requests (SSL handshakes)
+     * would fail since the local fingerprint data are still valid.
+     *
+     * Note that even though the local data are valid, there might be some remote changes
+     * (changed server certificate) and network requests (SSL handshakes) might still fail.
+     */
+    SILENT,
+
+    /**
+     * No update is performed.
+     *
+     * App con continue normally.
+     * There's no need to perform update based on the locally stored fingerprints.
+     *
+     * Note that even though the local data are valid, there might be some remote changes
+     * (changed server certificate) and network requests (SSL handshakes) might still fail.
+     */
+    NO_UPDATE;
+
+    /**
+     * Check if this type of update is actually performing update.
+     */
+    val isPerformingUpdate: Boolean
+    get() {
+        return this != NO_UPDATE
+    }
+}

--- a/library/src/main/java/com/wultra/android/sslpinning/ValidationObserver.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/ValidationObserver.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.wultra.android.sslpinning
+
+/**
+ * Observer for validation failures.
+ *
+ * When registered receives all validation failures happending on the given [CertStore].
+ * Callbacks are executed on the main thread.
+ *
+ * @author Tomas Kypta, tomas.kypta@wultra.com
+ *
+ * @since 0.9.0
+ */
+interface ValidationObserver {
+
+    /**
+     * Called when a validation for a common name is deemed [ValidationResult.UNTRUSTED].
+     *
+     * @param commonName The common name that was validated with result [ValidationResult.UNTRUSTED].
+     */
+    fun onValidationUntrusted(commonName: String)
+
+    /**
+     * Called when a validation for a common name is deemed [ValidationResult.EMPTY].
+     *
+     * @param commonName The common name that was validated with result [ValidationResult.EMPTY].
+     */
+    fun onValidationEmpty(commonName: String)
+}

--- a/library/src/main/java/com/wultra/android/sslpinning/ValidationObserver.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/ValidationObserver.kt
@@ -16,10 +16,12 @@
 
 package com.wultra.android.sslpinning
 
+import android.support.annotation.MainThread
+
 /**
  * Observer for validation failures.
  *
- * When registered receives all validation failures happending on the given [CertStore].
+ * When registered receives all validation failures happening on the given [CertStore].
  * Callbacks are executed on the main thread.
  *
  * @author Tomas Kypta, tomas.kypta@wultra.com
@@ -33,6 +35,7 @@ interface ValidationObserver {
      *
      * @param commonName The common name that was validated with result [ValidationResult.UNTRUSTED].
      */
+    @MainThread
     fun onValidationUntrusted(commonName: String)
 
     /**
@@ -40,5 +43,6 @@ interface ValidationObserver {
      *
      * @param commonName The common name that was validated with result [ValidationResult.EMPTY].
      */
+    @MainThread
     fun onValidationEmpty(commonName: String)
 }

--- a/library/src/main/java/com/wultra/android/sslpinning/ValidationResult.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/ValidationResult.kt
@@ -36,7 +36,7 @@ enum class ValidationResult {
      * Both these situations mean that the store is unable to determine whether the server
      * can be trusted or not.
      *
-     * In this case it is recommended to udpate the list of certificate fingerpritns
+     * In this case it is recommended to update the list of certificate fingerprints
      * and not to trust the server.
      */
     EMPTY

--- a/library/src/main/java/com/wultra/android/sslpinning/integration/DefaultUpdateObserver.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/integration/DefaultUpdateObserver.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.wultra.android.sslpinning.integration
+
+import com.wultra.android.sslpinning.UpdateObserver
+import com.wultra.android.sslpinning.UpdateResult
+import com.wultra.android.sslpinning.UpdateType
+
+/**
+ * Utility [UpdateObserver] that simplifies integration of CertStore udpates.
+ *
+ * It continues execution that's supposed to happen after successful
+ * [CertStore] update.
+ * @author Tomas Kypta, tomas.kypta@wultra.com
+ *
+ * @since 0.9.0
+ */
+abstract class DefaultUpdateObserver : UpdateObserver {
+
+    override fun onUpdateStarted(type: UpdateType) {
+        when (type) {
+            UpdateType.NO_UPDATE,
+            UpdateType.SILENT ->
+                continueExecution()
+            else -> {}
+        }
+    }
+
+    override fun onUpdateFinished(type: UpdateType, result: UpdateResult) {
+        if (result == UpdateResult.OK) {
+            if (type == UpdateType.DIRECT) {
+                continueExecution()
+            }
+        } else {
+            handleFailedUpdate(type, result)
+        }
+    }
+
+    /**
+     * Method to contain code that's supposed to run after successful CertStore update.
+     *
+     * The method is invoked when it's safe to continue with the execution.
+     * That means after finished [UpdateType.DIRECT] or after started
+     * [UpdateType.SILENT], [UpdateType.NO_UPDATE].
+     */
+    abstract fun continueExecution();
+
+    /**
+     * Common handling of failed update (not [UpdateResult.OK]).
+     *
+     * @param type Type of update
+     * @param result Result of the update.
+     */
+    open fun handleFailedUpdate(type: UpdateType, result: UpdateResult) {}
+}

--- a/library/src/main/java/com/wultra/android/sslpinning/integration/SSLPinningX509TrustManager.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/integration/SSLPinningX509TrustManager.kt
@@ -16,6 +16,7 @@
 
 package com.wultra.android.sslpinning.integration
 
+import android.annotation.SuppressLint
 import com.wultra.android.sslpinning.CertStore
 import com.wultra.android.sslpinning.ValidationResult
 import java.security.cert.CertificateException
@@ -29,6 +30,7 @@ import javax.net.ssl.X509TrustManager
  */
 class SSLPinningX509TrustManager(private val certStore: CertStore) : X509TrustManager {
 
+    @SuppressLint("TrustAllX509TrustManager")
     override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) {
     }
 

--- a/library/src/main/java/com/wultra/android/sslpinning/integration/powerauth/PowerAuthIntegration.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/integration/powerauth/PowerAuthIntegration.kt
@@ -21,7 +21,9 @@ import com.wultra.android.sslpinning.CertStore
 import com.wultra.android.sslpinning.CertStoreConfiguration
 
 /**
- * Creates a new instance of [CertStore] preconfigured with [CryptoProvider] and [SecureDataStore]
+ * Creates a new instance of [CertStore] preconfigured with
+ * [com.wultra.android.sslpinning.interfaces.CryptoProvider]
+ * and [com.wultra.android.sslpinning.interfaces.SecureDataStore]
  * implemented on top of PowerAuthSDK.
  *
  * @param configuration Configuration for [CertStore]
@@ -53,7 +55,9 @@ class PowerAuthCertStore {
     companion object {
 
         /**
-         * Creates a new instance of [CertStore] preconfigured with [CryptoProvider] and [SecureDataStore]
+         * Creates a new instance of [CertStore] preconfigured with
+         * [com.wultra.android.sslpinning.interfaces.CryptoProvider]
+         * and [com.wultra.android.sslpinning.interfaces.SecureDataStore]
          * implemented on top of PowerAuthSDK.
          *
          * @param configuration Configuration for [CertStore]

--- a/library/src/main/java/com/wultra/android/sslpinning/service/RemoteDataProvider.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/service/RemoteDataProvider.kt
@@ -31,7 +31,7 @@ interface RemoteDataProvider {
      *
      * Always invoke on a worker thread.
      *
-     * @return Bytes as recieved from the remote server. Typically containing data in JSON format.
+     * @return Bytes as received from the remote server. Typically containing data in JSON format.
      */
     @WorkerThread
     fun getFingerprints(): ByteArray

--- a/library/src/main/java/com/wultra/android/sslpinning/service/RestApi.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/service/RestApi.kt
@@ -23,7 +23,7 @@ import java.net.URL
 
 /**
  * Handling of network communication with the server.
- * Used internally in [CertStore].
+ * Used internally in [com.wultra.android.sslpinning.CertStore].
  *
  * @property baseUrl URL of the remote server.
  * @author Tomas Kypta, tomas.kypta@wultra.com
@@ -46,7 +46,7 @@ class RestApi(private val baseUrl: URL) : RemoteDataProvider {
     /**
      * Perform REST request to get fingerprints from the remote server.
      *
-     * @return Bytes as recieved from the remote server. Typically containing data in JSON format.
+     * @return Bytes as received from the remote server. Typically containing data in JSON format.
      */
     @WorkerThread
     override fun getFingerprints(): ByteArray {

--- a/library/src/main/java/com/wultra/android/sslpinning/service/UpdateScheduler.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/service/UpdateScheduler.kt
@@ -21,7 +21,7 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 
 /**
- * Helper class for calculatinngn date of the next update.
+ * Helper class for calculating date of the next update.
  *
  * @property periodicUpdateIntervalMillis Defines interval between checks for update of certificate fingerprints
  * @property expirationUpdateThresholdMillis Define time window in milliseconds before a certificate expires

--- a/library/src/test/java/com/wultra/android/sslpinning/CertStoreConfigurationTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/CertStoreConfigurationTest.java
@@ -16,19 +16,10 @@
 
 package com.wultra.android.sslpinning;
 
-import android.util.Base64;
-import android.util.Log;
-
-import com.wultra.android.sslpinning.interfaces.CryptoProvider;
-import com.wultra.android.sslpinning.interfaces.SecureDataStore;
 import com.wultra.android.sslpinning.model.GetFingerprintResponse;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.net.MalformedURLException;
@@ -40,42 +31,12 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Tomas Kypta, tomas.kypta@wultra.com
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({
-        Base64.class,
-        Log.class
-})
-public class CertStoreConfigurationTest {
-
-    @Mock
-    CryptoProvider cryptoProvider;
-
-    @Mock
-    SecureDataStore secureDataStore;
-
-    @Before
-    public void setUp() {
-        PowerMockito.mockStatic(Base64.class);
-        when(Base64.encodeToString(any(byte[].class), anyInt()))
-                .thenAnswer(invocation ->
-                        new String(java.util.Base64.getEncoder().encode((byte[]) invocation.getArgument(0)))
-                );
-
-        PowerMockito.mockStatic(Log.class);
-        when(Log.e(anyString(), anyString()))
-                .then(invocation -> {
-                    System.out.println((String) invocation.getArgument(1));
-                    return 0;
-                });
-    }
+public class CertStoreConfigurationTest extends CommonJavaTest {
 
     @Test
     public void testBasicConfiguration() throws Exception {
@@ -93,6 +54,7 @@ public class CertStoreConfigurationTest {
         CertStoreConfiguration config = configuration(new Date());
         assertNull(config.getFallbackCertificate());
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
+        TestUtils.assignHandler(store, handler);
 
         byte[] fingerprint = new byte[32];
         Arrays.fill(fingerprint, (byte)0xff);
@@ -105,6 +67,7 @@ public class CertStoreConfigurationTest {
         CertStoreConfiguration config = configurationWithFallback(null, null);
         assertNotNull(config.getFallbackCertificate());
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
+        TestUtils.assignHandler(store, handler);
 
         byte[] fingerprint = new byte[32];
         Arrays.fill(fingerprint, (byte)0xff);
@@ -118,6 +81,7 @@ public class CertStoreConfigurationTest {
         CertStoreConfiguration config = configurationWithFallback(expired, null);
         assertNotNull(config.getFallbackCertificate());
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
+        TestUtils.assignHandler(store, handler);
 
         byte[] fingerprint = new byte[32];
         Arrays.fill(fingerprint, (byte)0xff);
@@ -129,6 +93,7 @@ public class CertStoreConfigurationTest {
     public void testConfigurationWithNonMatchingExpectedCommonNames() throws Exception {
         CertStoreConfiguration config = configurationWithFallback(null, new String[]{"www.wultra.com"});
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
+        TestUtils.assignHandler(store, handler);
 
         byte[] fingerprint = new byte[32];
         Arrays.fill(fingerprint, (byte)0xff);
@@ -143,6 +108,7 @@ public class CertStoreConfigurationTest {
     public void testConfigurationWithMatchingExpectedCommonNames() throws Exception {
         CertStoreConfiguration config = configurationWithFallback(null, new String[]{"api.fallback.org"});
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
+        TestUtils.assignHandler(store, handler);
 
         byte[] fingerprint = new byte[32];
         Arrays.fill(fingerprint, (byte)0xff);

--- a/library/src/test/java/com/wultra/android/sslpinning/CertStoreUpdateTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/CertStoreUpdateTest.java
@@ -22,6 +22,7 @@ import com.wultra.android.sslpinning.interfaces.ECPublicKey;
 import com.wultra.android.sslpinning.interfaces.SignedData;
 import com.wultra.android.sslpinning.service.RemoteDataProvider;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -147,9 +148,19 @@ public class CertStoreUpdateTest extends CommonJavaTest {
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore, remoteDataProvider);
         TestUtils.assignHandler(store, handler);
 
-        boolean updateStarted = store.update(UpdateMode.FORCED);
+
+        store.update(UpdateMode.FORCED, new UpdateObserver() {
+            @Override
+            public void onUpdateInitiated(@NotNull UpdateType type) {
+                assertEquals(UpdateType.DIRECT, type);
+            }
+
+            @Override
+            public void onUpdateFinished(@NotNull UpdateResult result) {
+
+            }
+        });
         assertTrue(latch.await(2, TimeUnit.SECONDS));
-        assertTrue(updateStarted);
     }
 
     @NonNull

--- a/library/src/test/java/com/wultra/android/sslpinning/CertStoreUpdateTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/CertStoreUpdateTest.java
@@ -134,8 +134,7 @@ public class CertStoreUpdateTest extends CommonJavaTest {
 
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore, remoteDataProvider);
         TestUtils.assignHandler(store, handler);
-        UpdateResult updateResult = store.update(UpdateMode.FORCED);
-        assertEquals(UpdateResult.OK, updateResult);
+        TestUtils.updateAndCheck(store, UpdateMode.FORCED, UpdateResult.OK);
     }
 
     @NonNull
@@ -151,6 +150,7 @@ public class CertStoreUpdateTest extends CommonJavaTest {
                 null);
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
         TestUtils.assignHandler(store, handler);
-        return store.update(UpdateMode.FORCED);
+
+        return TestUtils.updateAndCheck(store, UpdateMode.FORCED, null);
     }
 }

--- a/library/src/test/java/com/wultra/android/sslpinning/CertStoreUpdateTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/CertStoreUpdateTest.java
@@ -18,6 +18,7 @@ package com.wultra.android.sslpinning;
 
 import android.support.annotation.NonNull;
 
+import com.wultra.android.sslpinning.integration.DefaultUpdateObserver;
 import com.wultra.android.sslpinning.interfaces.ECPublicKey;
 import com.wultra.android.sslpinning.interfaces.SignedData;
 import com.wultra.android.sslpinning.service.RemoteDataProvider;
@@ -35,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -149,14 +151,26 @@ public class CertStoreUpdateTest extends CommonJavaTest {
         TestUtils.assignHandler(store, handler);
 
 
-        store.update(UpdateMode.FORCED, new UpdateObserver() {
+        store.update(UpdateMode.FORCED, new DefaultUpdateObserver() {
             @Override
             public void onUpdateStarted(@NotNull UpdateType type) {
                 assertEquals(UpdateType.DIRECT, type);
+                super.onUpdateStarted(type);
             }
 
             @Override
-            public void onUpdateFinished(@NotNull UpdateResult result) {
+            public void onUpdateFinished(@NotNull UpdateType type, @NotNull UpdateResult result) {
+                assertEquals(UpdateType.DIRECT, type);
+                super.onUpdateFinished(type, result);
+            }
+
+            @Override
+            public void handleFailedUpdate(@NotNull UpdateType type, @NotNull UpdateResult result) {
+                fail();
+            }
+
+            @Override
+            public void continueExecution() {
 
             }
         });

--- a/library/src/test/java/com/wultra/android/sslpinning/CertStoreUpdateTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/CertStoreUpdateTest.java
@@ -17,42 +17,28 @@
 package com.wultra.android.sslpinning;
 
 import android.support.annotation.NonNull;
-import android.util.Log;
 
+import com.wultra.android.sslpinning.integration.powerauth.PA2ECPublicKey;
 import com.wultra.android.sslpinning.interfaces.CryptoProvider;
 import com.wultra.android.sslpinning.interfaces.ECPublicKey;
-import com.wultra.android.sslpinning.interfaces.SecureDataStore;
 import com.wultra.android.sslpinning.interfaces.SignedData;
-import com.wultra.android.sslpinning.integration.powerauth.PA2ECPublicKey;
 import com.wultra.android.sslpinning.service.RemoteDataProvider;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.MessageDigest;
-import java.security.Security;
 import java.util.Base64;
 import java.util.Date;
 
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.util.SignatureUtils;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
-import io.getlime.security.powerauth.provider.CryptoProviderUtilBouncyCastle;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -62,63 +48,7 @@ import static org.mockito.Mockito.when;
  * @author Tomas Kypta, tomas.kypta@wultra.com
  */
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({
-        "javax.net.ssl.*",
-        "javax.security.auth.x500.*",
-        "org.bouncycastle.*",
-        "java.security.*"
-})
-@PrepareForTest({
-        android.util.Base64.class,
-        Log.class
-})
-public class CertStoreUpdateTest {
-
-    @Mock
-    CryptoProvider cryptoProvider;
-
-    @Mock
-    SecureDataStore secureDataStore;
-
-    @BeforeClass
-    public static void setUpClass() {
-        Security.addProvider(new BouncyCastleProvider());
-        PowerAuthConfiguration.INSTANCE.setKeyConvertor(new CryptoProviderUtilBouncyCastle());
-    }
-
-    @Before
-    public void setUp() {
-        PowerMockito.mockStatic(android.util.Base64.class);
-        when(android.util.Base64.encodeToString(any(byte[].class), anyInt()))
-                .thenAnswer(invocation ->
-                        new String(java.util.Base64.getEncoder().encode((byte[]) invocation.getArgument(0)))
-                );
-        when(android.util.Base64.encode(any(byte[].class), anyInt()))
-                .thenAnswer(invocation ->
-                        java.util.Base64.getEncoder().encode((byte[]) invocation.getArgument(0))
-                );
-        when(android.util.Base64.decode(anyString(), anyInt()))
-                .thenAnswer(invocation ->
-                        Base64.getDecoder().decode((String)invocation.getArgument(0))
-                );
-
-        PowerMockito.mockStatic(Log.class);
-        when(Log.e(anyString(), anyString()))
-                .then(invocation -> {
-                    System.out.println((String) invocation.getArgument(1));
-                    return 0;
-                });
-        when(cryptoProvider.hashSha256(any(byte[].class)))
-                .thenAnswer(invocation -> {
-                    MessageDigest digest = MessageDigest.getInstance("SHA-256");
-                    return digest.digest(invocation.getArgument(0));
-                });
-        when(cryptoProvider.importECPublicKey(any(byte[].class)))
-                .thenAnswer(invocation ->
-                        new PA2ECPublicKey(invocation.getArgument(0))
-                );
-
-    }
+public class CertStoreUpdateTest extends CommonJavaTest {
 
     @Test
     public void testCorrectUpdate() throws Exception {
@@ -203,12 +133,13 @@ public class CertStoreUpdateTest {
                 });
 
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore, remoteDataProvider);
+        TestUtils.assignHandler(store, handler);
         UpdateResult updateResult = store.update(UpdateMode.FORCED);
         assertEquals(UpdateResult.OK, updateResult);
     }
 
     @NonNull
-    private UpdateResult performForcedUpdate(String pinningJsonUrl) throws MalformedURLException {
+    private UpdateResult performForcedUpdate(String pinningJsonUrl) throws Exception {
         String publicKey = "BC3kV9OIDnMuVoCdDR9nEA/JidJLTTDLuSA2TSZsGgODSshfbZg31MS90WC/HdbU/A5WL5GmyDkE/iks6INv+XE=";
         byte[] publicKeyBytes = Base64.getDecoder().decode(publicKey);
 
@@ -219,6 +150,7 @@ public class CertStoreUpdateTest {
                 publicKeyBytes,
                 null);
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
+        TestUtils.assignHandler(store, handler);
         return store.update(UpdateMode.FORCED);
     }
 }

--- a/library/src/test/java/com/wultra/android/sslpinning/CertStoreUpdateTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/CertStoreUpdateTest.java
@@ -151,7 +151,7 @@ public class CertStoreUpdateTest extends CommonJavaTest {
 
         store.update(UpdateMode.FORCED, new UpdateObserver() {
             @Override
-            public void onUpdateInitiated(@NotNull UpdateType type) {
+            public void onUpdateStarted(@NotNull UpdateType type) {
                 assertEquals(UpdateType.DIRECT, type);
             }
 

--- a/library/src/test/java/com/wultra/android/sslpinning/CertStoreValidationTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/CertStoreValidationTest.java
@@ -16,115 +16,27 @@
 
 package com.wultra.android.sslpinning;
 
-import android.util.Log;
-
-import com.wultra.android.sslpinning.interfaces.CryptoProvider;
-import com.wultra.android.sslpinning.interfaces.ECPublicKey;
-import com.wultra.android.sslpinning.interfaces.SecureDataStore;
-import com.wultra.android.sslpinning.interfaces.SignedData;
 import com.wultra.android.sslpinning.model.GetFingerprintResponse;
-import com.wultra.android.sslpinning.integration.powerauth.PA2ECPublicKey;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.net.URL;
-import java.security.MessageDigest;
-import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
-import io.getlime.security.powerauth.crypto.lib.util.SignatureUtils;
-import io.getlime.security.powerauth.provider.CryptoProviderUtil;
-import io.getlime.security.powerauth.provider.CryptoProviderUtilBouncyCastle;
-
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
 
 /**
+ * Tests for validation with [CertStore].
+ *
  * @author Tomas Kypta, tomas.kypta@wultra.com
  */
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({
-        "javax.net.ssl.*",
-        "javax.security.auth.x500.*",
-        "org.bouncycastle.*",
-        "java.security.*"
-})
-@PrepareForTest({
-        android.util.Base64.class,
-        Log.class
-})
-public class CertStoreValidationTest {
-
-    @Mock
-    CryptoProvider cryptoProvider;
-
-    @Mock
-    SecureDataStore secureDataStore;
-
-    @BeforeClass
-    public static void setUpClass() {
-        Security.addProvider(new BouncyCastleProvider());
-        PowerAuthConfiguration.INSTANCE.setKeyConvertor(new CryptoProviderUtilBouncyCastle());
-    }
-
-    @Before
-    public void setUp() {
-        PowerMockito.mockStatic(android.util.Base64.class);
-        when(android.util.Base64.encodeToString(any(byte[].class), anyInt()))
-                .thenAnswer(invocation ->
-                        new String(java.util.Base64.getEncoder().encode((byte[]) invocation.getArgument(0)))
-                );
-        when(android.util.Base64.encode(any(byte[].class), anyInt()))
-                .thenAnswer(invocation ->
-                        java.util.Base64.getEncoder().encode((byte[]) invocation.getArgument(0))
-                );
-        when(android.util.Base64.decode(anyString(), anyInt()))
-                .thenAnswer(invocation ->
-                        Base64.getDecoder().decode((String)invocation.getArgument(0))
-                );
-
-        PowerMockito.mockStatic(Log.class);
-        when(Log.e(anyString(), anyString()))
-                .then(invocation -> {
-                    System.out.println((String) invocation.getArgument(1));
-                    return 0;
-                });
-        when(cryptoProvider.hashSha256(any(byte[].class)))
-                .thenAnswer(invocation -> {
-                    MessageDigest digest = MessageDigest.getInstance("SHA-256");
-                    return digest.digest(invocation.getArgument(0));
-                });
-        when(cryptoProvider.importECPublicKey(any(byte[].class)))
-                .thenAnswer(invocation ->
-                        new PA2ECPublicKey(invocation.getArgument(0))
-                );
-        when(cryptoProvider.ecdsaValidateSignatures(any(SignedData.class), any(ECPublicKey.class)))
-                .thenAnswer(invocation -> {
-                    SignatureUtils utils = new SignatureUtils();
-                    SignedData signedData = invocation.getArgument(0);
-                    PA2ECPublicKey pubKey = invocation.getArgument(1);
-                    final CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
-                    return utils.validateECDSASignature(signedData.getData(),
-                            signedData.getSignature(),
-                            keyConvertor.convertBytesToPublicKey(pubKey.getData()));
-                });
-    }
+public class CertStoreValidationTest extends CommonJavaTest {
 
     @Test
     public void testValidationGithubFallback() throws Exception {
@@ -151,6 +63,7 @@ public class CertStoreValidationTest {
                 publicKeyBytes,
                 fallback);
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
+        TestUtils.assignHandler(store, handler);
         ValidationResult result = store.validateCertificate(cert);
         assertEquals(ValidationResult.TRUSTED, result);
     }
@@ -169,6 +82,7 @@ public class CertStoreValidationTest {
                 publicKeyBytes,
                 null);
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
+        TestUtils.assignHandler(store, handler);
         UpdateResult updateResult = store.update(UpdateMode.FORCED);
         assertEquals(UpdateResult.OK, updateResult);
 

--- a/library/src/test/java/com/wultra/android/sslpinning/CertStoreValidationTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/CertStoreValidationTest.java
@@ -83,8 +83,7 @@ public class CertStoreValidationTest extends CommonJavaTest {
                 null);
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
         TestUtils.assignHandler(store, handler);
-        UpdateResult updateResult = store.update(UpdateMode.FORCED);
-        assertEquals(UpdateResult.OK, updateResult);
+        TestUtils.updateAndCheck(store, UpdateMode.FORCED, UpdateResult.OK);
 
         ValidationResult result = store.validateCertificate(cert);
         assertEquals(ValidationResult.TRUSTED, result);

--- a/library/src/test/java/com/wultra/android/sslpinning/CommonJavaTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/CommonJavaTest.java
@@ -134,7 +134,8 @@ public abstract class CommonJavaTest {
         when(handler.post(any()))
                 .thenAnswer(invocation -> {
                     Runnable runnable = invocation.getArgument(0);
-                    runnable.run();
+                    Thread t = new Thread(runnable);
+                    t.start();
                     return true;
                 });
     }

--- a/library/src/test/java/com/wultra/android/sslpinning/CommonJavaTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/CommonJavaTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.wultra.android.sslpinning;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import com.wultra.android.sslpinning.integration.powerauth.PA2ECPublicKey;
+import com.wultra.android.sslpinning.interfaces.CryptoProvider;
+import com.wultra.android.sslpinning.interfaces.ECPublicKey;
+import com.wultra.android.sslpinning.interfaces.SecureDataStore;
+import com.wultra.android.sslpinning.interfaces.SignedData;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+
+import java.security.MessageDigest;
+import java.security.Security;
+import java.util.Base64;
+
+import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
+import io.getlime.security.powerauth.crypto.lib.util.SignatureUtils;
+import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.provider.CryptoProviderUtilBouncyCastle;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Common setup for java-based tests.
+ *
+ * @author Tomas Kypta, tomas.kypta@wultra.com
+ */
+@PowerMockIgnore({
+        "javax.net.ssl.*",
+        "javax.security.auth.x500.*",
+        "org.bouncycastle.*",
+        "java.security.*"
+})
+@PrepareForTest({
+        android.util.Base64.class,
+        Log.class,
+        Looper.class
+})
+public abstract class CommonJavaTest {
+
+    @Mock
+    protected Context context;
+
+    @Mock
+    protected CryptoProvider cryptoProvider;
+
+    @Mock
+    protected SecureDataStore secureDataStore;
+
+    @Mock
+    protected Handler handler;
+
+    @BeforeClass
+    public static void setUpClass() {
+        Security.addProvider(new BouncyCastleProvider());
+        PowerAuthConfiguration.INSTANCE.setKeyConvertor(new CryptoProviderUtilBouncyCastle());
+    }
+
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(android.util.Base64.class);
+        when(android.util.Base64.encodeToString(any(byte[].class), anyInt()))
+                .thenAnswer(invocation ->
+                        new String(java.util.Base64.getEncoder().encode((byte[]) invocation.getArgument(0)))
+                );
+        when(android.util.Base64.encode(any(byte[].class), anyInt()))
+                .thenAnswer(invocation ->
+                        java.util.Base64.getEncoder().encode((byte[]) invocation.getArgument(0))
+                );
+        when(android.util.Base64.decode(anyString(), anyInt()))
+                .thenAnswer(invocation ->
+                        Base64.getDecoder().decode((String) invocation.getArgument(0))
+                );
+
+        PowerMockito.mockStatic(Log.class);
+        when(Log.e(anyString(), anyString()))
+                .then(invocation -> {
+                    System.out.println((String) invocation.getArgument(1));
+                    return 0;
+                });
+        when(cryptoProvider.hashSha256(any(byte[].class)))
+                .thenAnswer(invocation -> {
+                    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+                    return digest.digest(invocation.getArgument(0));
+                });
+        when(cryptoProvider.importECPublicKey(any(byte[].class)))
+                .thenAnswer(invocation ->
+                        new PA2ECPublicKey(invocation.getArgument(0))
+                );
+        when(cryptoProvider.ecdsaValidateSignatures(any(SignedData.class), any(ECPublicKey.class)))
+                .thenAnswer(invocation -> {
+                    SignatureUtils utils = new SignatureUtils();
+                    SignedData signedData = invocation.getArgument(0);
+                    PA2ECPublicKey pubKey = invocation.getArgument(1);
+                    final CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
+                    return utils.validateECDSASignature(signedData.getData(),
+                            signedData.getSignature(),
+                            keyConvertor.convertBytesToPublicKey(pubKey.getData()));
+                });
+
+        PowerMockito.mockStatic(Looper.class);
+        when(Looper.getMainLooper())
+                .thenReturn(null);
+
+        when(handler.post(any()))
+                .thenAnswer(invocation -> {
+                    Runnable runnable = invocation.getArgument(0);
+                    runnable.run();
+                    return true;
+                });
+    }
+}

--- a/library/src/test/java/com/wultra/android/sslpinning/CommonKotlinTest.kt
+++ b/library/src/test/java/com/wultra/android/sslpinning/CommonKotlinTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.wultra.android.sslpinning
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Base64
+import android.util.Log
+import com.wultra.android.sslpinning.integration.powerauth.PA2ECPublicKey
+import com.wultra.android.sslpinning.interfaces.CryptoProvider
+import com.wultra.android.sslpinning.interfaces.ECPublicKey
+import com.wultra.android.sslpinning.interfaces.SecureDataStore
+import com.wultra.android.sslpinning.interfaces.SignedData
+import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration
+import io.getlime.security.powerauth.crypto.lib.util.SignatureUtils
+import io.getlime.security.powerauth.provider.CryptoProviderUtilBouncyCastle
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.Before
+import org.junit.BeforeClass
+import org.mockito.ArgumentMatchers
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.powermock.api.mockito.PowerMockito
+import org.powermock.core.classloader.annotations.PowerMockIgnore
+import org.powermock.core.classloader.annotations.PrepareForTest
+import java.security.MessageDigest
+import java.security.Security
+
+/**
+ * Common setup for Kotlin-based tests.
+ *
+ * @author Tomas Kypta, tomas.kypta@wultra.com
+ */
+@PowerMockIgnore("javax.net.ssl.*", "javax.security.auth.x500.*", "org.bouncycastle.*", "java.security.*")
+@PrepareForTest(Base64::class,
+        Log::class,
+        Looper::class)
+open class CommonKotlinTest {
+
+    @Mock
+    lateinit var cryptoProvider: CryptoProvider
+
+    @Mock
+    lateinit var secureDataStore: SecureDataStore
+
+    @Mock
+    lateinit var handler: Handler
+
+    @Mock
+    lateinit var context: Context
+
+    companion object {
+
+        @BeforeClass
+        @JvmStatic
+        fun setUpClass() {
+            Security.addProvider(BouncyCastleProvider())
+            PowerAuthConfiguration.INSTANCE.keyConvertor = CryptoProviderUtilBouncyCastle()
+        }
+    }
+
+    fun <T> any(): T = Mockito.any<T>()
+
+    @Before
+    fun setUp() {
+        PowerMockito.mockStatic(Base64::class.java)
+        Mockito.`when`<String>(Base64.encodeToString(any<ByteArray>(), ArgumentMatchers.anyInt()))
+                .thenAnswer({ invocation -> String(java.util.Base64.getEncoder().encode(invocation.getArgument(0) as ByteArray)) }
+                )
+        Mockito.`when`<ByteArray>(Base64.encode(any<ByteArray>(), ArgumentMatchers.anyInt()))
+                .thenAnswer({ invocation -> java.util.Base64.getEncoder().encode(invocation.getArgument(0) as ByteArray) }
+                )
+        Mockito.`when`<ByteArray>(Base64.decode(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt()))
+                .thenAnswer({ invocation -> java.util.Base64.getDecoder().decode(invocation.getArgument(0) as String) }
+                )
+
+        PowerMockito.mockStatic(Log::class.java)
+        Mockito.`when`<Int>(Log.e(ArgumentMatchers.anyString(), ArgumentMatchers.anyString()))
+                .then({ invocation ->
+                    println(invocation.getArgument(1) as String)
+                    0
+                })
+        Mockito.`when`<ByteArray>(cryptoProvider.hashSha256(any<ByteArray>()))
+                .thenAnswer({ invocation ->
+                    val digest = MessageDigest.getInstance("SHA-256")
+                    digest.digest(invocation.getArgument(0))
+                })
+        Mockito.`when`<ECPublicKey>(cryptoProvider.importECPublicKey(any<ByteArray>()))
+                .thenAnswer({ invocation -> PA2ECPublicKey(invocation.getArgument(0)) }
+                )
+        Mockito.`when`<Boolean>(cryptoProvider.ecdsaValidateSignatures(any<SignedData>(), any<ECPublicKey>()))
+                .thenAnswer({ invocation ->
+                    val utils = SignatureUtils()
+                    val signedData: SignedData = invocation.getArgument(0)
+                    val pubKey: PA2ECPublicKey = invocation.getArgument(1)
+                    val keyConvertor = PowerAuthConfiguration.INSTANCE.keyConvertor
+                    utils.validateECDSASignature(signedData.data,
+                            signedData.signature,
+                            keyConvertor.convertBytesToPublicKey(pubKey.data))
+                })
+
+        PowerMockito.mockStatic(Looper::class.java)
+        Mockito.`when`<Looper>(Looper.getMainLooper())
+                .thenReturn(null)
+
+        Mockito.`when`<Boolean>(handler.post(any()))
+                .then({ invocation ->
+                    val runnable = invocation.getArgument<Runnable>(0)
+                    runnable.run()
+                    return@then true
+                })
+    }
+}

--- a/library/src/test/java/com/wultra/android/sslpinning/TestUtils.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/TestUtils.java
@@ -16,9 +16,12 @@
 
 package com.wultra.android.sslpinning;
 
+import android.os.Handler;
+
 import com.wultra.android.sslpinning.model.GetFingerprintResponse;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.security.cert.Certificate;
@@ -52,5 +55,11 @@ public class TestUtils {
                 .expectedCommonNames(expectedCommonNames)
                 .fallbackCertificate(fallback);
         return builder.build();
+    }
+
+    public static void assignHandler(CertStore certStore, Handler handler) throws Exception {
+        Field handlerField = CertStore.class.getDeclaredField("mainThreadHandler");
+        handlerField.setAccessible(true);
+        handlerField.set(certStore, handler);
     }
 }

--- a/library/src/test/java/com/wultra/android/sslpinning/TestUtils.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/TestUtils.java
@@ -83,7 +83,7 @@ public class TestUtils {
             }
 
             @Override
-            public void onUpdateFinished(@NotNull UpdateResult result) {
+            public void onUpdateFinished(@NotNull UpdateType type, @NotNull UpdateResult result) {
                 updateWrapper.setUpdateResult(result);
                 latch.countDown();
             }

--- a/library/src/test/java/com/wultra/android/sslpinning/TestUtils.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/TestUtils.java
@@ -77,7 +77,7 @@ public class TestUtils {
         UpdateWrapper updateWrapper = new UpdateWrapper();
         store.update(updateMode, new UpdateObserver() {
             @Override
-            public void onUpdateInitiated(@NotNull UpdateType type) {
+            public void onUpdateStarted(@NotNull UpdateType type) {
                 updateWrapper.setUpdateType(type);
                 initLatch.countDown();
             }

--- a/library/src/test/java/com/wultra/android/sslpinning/UpdateResultWrapper.kt
+++ b/library/src/test/java/com/wultra/android/sslpinning/UpdateResultWrapper.kt
@@ -17,30 +17,8 @@
 package com.wultra.android.sslpinning
 
 /**
- * Result of update request.
+ * Helper wrapper for passing update result outside of callbacks.
  *
  * @author Tomas Kypta, tomas.kypta@wultra.com
  */
-enum class UpdateResult {
-    /**
-     * Update succeeded. Everything is ok.
-     */
-    OK,
-    /**
-     * [CertStore] is empty. There's no valid certificate fingeprint to validate server cert against.
-     * Might happen when all the certificate fingerprints are already expired.
-     */
-    STORE_IS_EMPTY,
-    /**
-     * There was an error in network communication with the server.
-     */
-    NETWORK_ERROR,
-    /**
-     * The update request returned invalid data from the server.
-     */
-    INVALID_DATA,
-    /**
-     * The update request returned data which did not pass the signature validation.
-     */
-    INVALID_SIGNATURE
-}
+data class UpdateResultWrapper(var updateResult: UpdateResult? = null)

--- a/library/src/test/java/com/wultra/android/sslpinning/UpdateWrapper.kt
+++ b/library/src/test/java/com/wultra/android/sslpinning/UpdateWrapper.kt
@@ -17,8 +17,9 @@
 package com.wultra.android.sslpinning
 
 /**
- * Helper wrapper for passing update result outside of callbacks.
+ * Helper wrapper for passing update type and result outside of callbacks.
  *
  * @author Tomas Kypta, tomas.kypta@wultra.com
  */
-data class UpdateResultWrapper(var updateResult: UpdateResult? = null)
+data class UpdateWrapper(var updateResult: UpdateResult? = null,
+                         var updateType: UpdateType? = null)

--- a/library/src/test/java/com/wultra/android/sslpinning/ValidationObserverTest.kt
+++ b/library/src/test/java/com/wultra/android/sslpinning/ValidationObserverTest.kt
@@ -60,8 +60,7 @@ class ValidationObserverTest : CommonKotlinTest() {
         verify(observer, times(1)).onValidationEmpty(anyString())
         store.removeValidationObserver(observer)
 
-        val updateResult = store.update(UpdateMode.FORCED)
-        assertEquals(UpdateResult.OK, updateResult)
+        TestUtils.updateAndCheck(store, UpdateMode.FORCED, UpdateResult.OK)
 
         observer = mock(ValidationObserver::class.java)
         store.addValidationObserver(observer)

--- a/library/src/test/java/com/wultra/android/sslpinning/ValidationObserverTest.kt
+++ b/library/src/test/java/com/wultra/android/sslpinning/ValidationObserverTest.kt
@@ -28,7 +28,7 @@ import java.util.*
 import org.mockito.Mockito.`when` as wh
 
 /**
- * Test gloval validation observers.
+ * Test global validation observers.
  *
  * @author Tomas Kypta, tomas.kypta@wultra.com
  */

--- a/library/src/test/java/com/wultra/android/sslpinning/ValidationObserverTest.kt
+++ b/library/src/test/java/com/wultra/android/sslpinning/ValidationObserverTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.wultra.android.sslpinning
+
+import com.wultra.android.sslpinning.TestUtils.assignHandler
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.*
+import org.powermock.modules.junit4.PowerMockRunner
+import java.net.URL
+import java.util.*
+import org.mockito.Mockito.`when` as wh
+
+/**
+ * Test gloval validation observers.
+ *
+ * @author Tomas Kypta, tomas.kypta@wultra.com
+ */
+@RunWith(PowerMockRunner::class)
+class ValidationObserverTest : CommonKotlinTest() {
+
+    @Test
+    fun testValidationObservers() {
+        val cert = TestUtils.getCertificateFromUrl("https://github.com")
+        val certGoogle = TestUtils.getCertificateFromUrl("https://google.com")
+
+        val publicKey = "BC3kV9OIDnMuVoCdDR9nEA/JidJLTTDLuSA2TSZsGgODSshfbZg31MS90WC/HdbU/A5WL5GmyDkE/iks6INv+XE="
+        val publicKeyBytes = java.util.Base64.getDecoder().decode(publicKey)
+
+        val config = TestUtils.getCertStoreConfiguration(
+                Date(),
+                arrayOf("github.com"),
+                URL("https://gist.githubusercontent.com/hvge/7c5a3f9ac50332a52aa974d90ea2408c/raw/c5b021db0fcd40b1262ab513bf375e4641834925/ssl-pinning-signatures.json"),
+                publicKeyBytes,
+                null)
+        val store = CertStore(config, cryptoProvider, secureDataStore)
+        assignHandler(store, handler)
+
+        var observer: ValidationObserver = mock(ValidationObserver::class.java)
+        store.addValidationObserver(observer)
+        val result = store.validateCertificate(cert)
+        assertEquals(ValidationResult.EMPTY, result)
+        verify(observer, times(0)).onValidationUntrusted(anyString())
+        verify(observer, times(1)).onValidationEmpty(anyString())
+        store.removeValidationObserver(observer)
+
+        val updateResult = store.update(UpdateMode.FORCED)
+        assertEquals(UpdateResult.OK, updateResult)
+
+        observer = mock(ValidationObserver::class.java)
+        store.addValidationObserver(observer)
+        val result2 = store.validateCertificate(cert)
+        assertEquals(ValidationResult.TRUSTED, result2)
+        verify(observer, times(0)).onValidationUntrusted(anyString())
+        verify(observer, times(0)).onValidationEmpty(anyString())
+        store.removeAllValidationObservers()
+
+        observer = mock(ValidationObserver::class.java)
+        store.addValidationObserver(observer)
+        val result3 = store.validateCertificate(certGoogle)
+        assertEquals(ValidationResult.UNTRUSTED, result3)
+        verify(observer, times(1)).onValidationUntrusted(anyString())
+        verify(observer, times(0)).onValidationEmpty(anyString())
+        store.removeAllValidationObservers()
+    }
+}

--- a/library/src/test/java/com/wultra/android/sslpinning/integration/SSLPinningIntegrationTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/integration/SSLPinningIntegrationTest.java
@@ -16,17 +16,16 @@
 
 package com.wultra.android.sslpinning.integration;
 
-import android.content.Context;
-
 import com.wultra.android.sslpinning.CertStore;
 import com.wultra.android.sslpinning.CertStoreConfiguration;
+import com.wultra.android.sslpinning.CommonJavaTest;
+import com.wultra.android.sslpinning.TestUtils;
 import com.wultra.android.sslpinning.integration.powerauth.PowerAuthCertStore;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.net.URL;
 
@@ -37,11 +36,8 @@ import javax.net.ssl.SSLSocketFactory;
  *
  * @author Tomas Kypta, tomas.kypta@wultra.com
  */
-@RunWith(MockitoJUnitRunner.class)
-public class SSLPinningIntegrationTest {
-
-    @Mock
-    Context context;
+@RunWith(PowerMockRunner.class)
+public class SSLPinningIntegrationTest extends CommonJavaTest {
 
     @Test
     public void testSSLPinningIntegrationApis() throws Exception {
@@ -52,6 +48,8 @@ public class SSLPinningIntegrationTest {
         CertStoreConfiguration configuration = new CertStoreConfiguration.Builder(url, publicKeyBytes)
                 .build();
         CertStore store = PowerAuthCertStore.createInstance(configuration, context);
+        TestUtils.assignHandler(store, handler);
+
         Assert.assertNotNull(store);
 
         SSLSocketFactory factory1 = SSLPinningIntegration.createSSLPinningSocketFactory(store);

--- a/library/src/test/java/com/wultra/android/sslpinning/integration/powerauth/PowerAuthIntegrationTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/integration/powerauth/PowerAuthIntegrationTest.java
@@ -16,19 +16,15 @@
 
 package com.wultra.android.sslpinning.integration.powerauth;
 
-import android.content.Context;
-
 import com.wultra.android.sslpinning.CertStore;
 import com.wultra.android.sslpinning.CertStoreConfiguration;
-import com.wultra.android.sslpinning.integration.powerauth.PowerAuthCertStore;
-import com.wultra.android.sslpinning.integration.powerauth.PowerAuthIntegrationKt;
-import com.wultra.android.sslpinning.integration.powerauth.PowerAuthSecureDataStore;
+import com.wultra.android.sslpinning.CommonJavaTest;
+import com.wultra.android.sslpinning.TestUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.net.URL;
 
@@ -37,11 +33,8 @@ import java.net.URL;
  *
  * @author Tomas Kypta, tomas.kypta@wultra.com
  */
-@RunWith(MockitoJUnitRunner.class)
-public class PowerAuthIntegrationTest {
-
-    @Mock
-    Context context;
+@RunWith(PowerMockRunner.class)
+public class PowerAuthIntegrationTest extends CommonJavaTest {
 
     @Test
     public void testPowerAuthCertStoreApis() throws Exception {
@@ -52,14 +45,18 @@ public class PowerAuthIntegrationTest {
         CertStoreConfiguration configuration = new CertStoreConfiguration.Builder(url, publicKeyBytes)
                 .build();
         CertStore store1 = PowerAuthCertStore.Companion.createInstance(configuration, context, null);
+        TestUtils.assignHandler(store1, handler);
         Assert.assertNotNull(store1);
         CertStore store2 = PowerAuthCertStore.createInstance(configuration, context, null);
+        TestUtils.assignHandler(store2, handler);
         Assert.assertNotNull(store2);
         CertStore store3 = PowerAuthCertStore.createInstance(configuration, context);
+        TestUtils.assignHandler(store3, handler);
         Assert.assertNotNull(store3);
 
         // Kotlin API inconvenient for calling from Java
         CertStore store4 = PowerAuthIntegrationKt.powerAuthCertStore(CertStore.Companion, configuration, context, "");
+        TestUtils.assignHandler(store4, handler);
         Assert.assertNotNull(store4);
     }
 

--- a/library/src/test/java/com/wultra/android/sslpinning/integration/powerauth/PowerAuthIntegrationTestKt.kt
+++ b/library/src/test/java/com/wultra/android/sslpinning/integration/powerauth/PowerAuthIntegrationTestKt.kt
@@ -16,14 +16,14 @@
 
 package com.wultra.android.sslpinning.integration.powerauth
 
-import android.content.Context
 import com.wultra.android.sslpinning.CertStore
 import com.wultra.android.sslpinning.CertStoreConfiguration
+import com.wultra.android.sslpinning.CommonKotlinTest
+import com.wultra.android.sslpinning.TestUtils
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
+import org.powermock.modules.junit4.PowerMockRunner
 import java.net.URL
 
 /**
@@ -31,11 +31,8 @@ import java.net.URL
  *
  * @author Tomas Kypta, tomas.kypta@wultra.com
  */
-@RunWith(MockitoJUnitRunner::class)
-class PowerAuthIntegrationTestKt {
-
-    @Mock
-    internal lateinit var context: Context
+@RunWith(PowerMockRunner::class)
+class PowerAuthIntegrationTestKt : CommonKotlinTest() {
 
     @Test
     fun testApis() {
@@ -46,12 +43,15 @@ class PowerAuthIntegrationTestKt {
         val configuration = CertStoreConfiguration.Builder(url, publicKeyBytes)
                 .build()
         val store1 = PowerAuthCertStore.createInstance(configuration, context, null)
+        TestUtils.assignHandler(store1, handler)
         Assert.assertNotNull(store1)
         val store2 = PowerAuthCertStore.createInstance(configuration, context)
+        TestUtils.assignHandler(store2, handler)
         Assert.assertNotNull(store2)
 
         // Kotlin API
         val store3 = CertStore.powerAuthCertStore(configuration, context, "")
+        TestUtils.assignHandler(store3, handler)
         Assert.assertNotNull(store3)
     }
 }

--- a/library/src/test/java/com/wultra/android/sslpinning/integration/powerauth/PowerAuthSslPinningValidationStrategyTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/integration/powerauth/PowerAuthSslPinningValidationStrategyTest.java
@@ -65,8 +65,7 @@ public class PowerAuthSslPinningValidationStrategyTest extends CommonJavaTest {
                 null);
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
         TestUtils.assignHandler(store, handler);
-        UpdateResult updateResult = store.update(UpdateMode.FORCED);
-        assertEquals(UpdateResult.OK, updateResult);
+        TestUtils.updateAndCheck(store, UpdateMode.FORCED, UpdateResult.OK);
 
         PA2ClientValidationStrategy strategy = new PowerAuthSslPinningValidationStrategy(store);
 


### PR DESCRIPTION
Add observers for updates and global observers for validation failures.
Change update method to be asynchronous with observer.
Add method for checking if update is necessary (without invoking the update).