### PR TITLE
Add test coverage tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@
 buildscript {
     ext.kotlin_version = '1.2.71'
     ext.dokkaVersion = '0.9.17'
+    ext.jacocoVersion = "0.8.2"
     repositories {
         jcenter()
         google()
@@ -28,6 +29,7 @@ buildscript {
         // releasing
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
+        classpath "org.jacoco:org.jacoco.core:${jacocoVersion}"
     }
 }
 

--- a/library/android-coverage.gradle
+++ b/library/android-coverage.gradle
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+apply plugin: 'jacoco'
+
+
+jacoco {
+    toolVersion = rootProject.ext.jacocoVersion
+}
+
+/**
+ * Create coverage report for unit tests ('src/test' source set).
+ */
+task unitTestCoverageReport(type: JacocoReport,
+        group: 'verification',
+        description: 'Creates unit test coverage report (for tests under \'test\' source set).',
+        dependsOn: ['testDebugUnitTest']) {
+
+    reports {
+        html.enabled = true
+    }
+
+    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
+    def debugKotlinTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/debug", excludes: fileFilter)
+    def debugJavaTree = fileTree(dir: "$project.buildDir/intermediates/javac/debug", excludes: fileFilter)
+    def mainSrc = "${project.projectDir}/src/main/java"
+
+    sourceDirectories = files([mainSrc])
+    classDirectories = files([debugKotlinTree, debugJavaTree])
+    executionData = fileTree(dir: "$buildDir", includes: [
+            "jacoco/testDebugUnitTest.exec"
+    ])
+}
+
+/**
+ * Create unified coverage report for unit tests and instrumentated tests ('src/test' and 'src/androidTest' source sets).
+ */
+task unifiedCoverageReport(type: JacocoReport,
+        group: 'verification',
+        description: 'Creates unified test coverage report for unit tests (under \'test\' source set)' +
+                ' and instrumentation tests (under \'androidTest\' source set).',
+        dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport', 'unitTestCoverageReport']) {
+
+    reports {
+        html.enabled = true
+    }
+
+    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
+    def debugKotlinTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/debug", excludes: fileFilter)
+    def debugJavaTree = fileTree(dir: "$project.buildDir/intermediates/javac/debug", excludes: fileFilter)
+    def mainSrc = "${project.projectDir}/src/main/java"
+
+    sourceDirectories = files([mainSrc])
+    classDirectories = files([debugKotlinTree, debugJavaTree])
+    executionData = fileTree(dir: "$buildDir", includes: [
+            "jacoco/testDebugUnitTest.exec",
+            "intermediates/jacoco_coverage_dir/debugAndroidTest/connectedDebugAndroidTest/code-coverage/*coverage.ec"
+    ])
+}
+

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -28,9 +28,13 @@ android {
         versionName VERSION_NAME
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments clearPackageData: 'true'
     }
 
     buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
         release {
             minifyEnabled false
             consumerProguardFiles 'proguard-rules.pro'
@@ -72,4 +76,4 @@ dependencies {
 }
 
 apply from: 'android-release-aar.gradle'
-
+apply from: 'android-coverage.gradle'


### PR DESCRIPTION
Add tasks for generating reports for unit test coverage.
And for unified (unit test and instrumentation test) coverage.
Note: Coverage report for instrumentation test is
built in the Android plugin.