### PR TITLE
Multiple fallback certs & trusted observer

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ val configuration = CertStoreConfiguration.Builder(
                             publicKey = publicKey)
                         .identifier(identifier)
                         .expectedCommonNames(expectedCommonNames)
-                        .fallbackCertificate(fallbackCertificate)
+                        .fallbackCertificates(fallbackCertificates)
                         .build()
 val certStore = CertStore.powerAuthCertStore(configuration = configuration, appContext)
 ```
@@ -101,7 +101,7 @@ The configuration has the following properties:
 - `publicKey` - byte array containing the public key counterpart to the private key, used for fingerprint signing.
 - `expectedCommonNames` - an optional array of strings, defining which domains you expect in certificate validation.
 - `identifier` - optional string identifier for scenarios, where multiple `CertStore` instances are used in the application.
-- `fallbackCertificateData` - optional hardcoded data for a fallback fingerprint. See the next chapter of this document for details.
+- `fallbackCertificates` - optional hardcoded data for a fallback fingerprints. See the next chapter of this document for details.
 - `periodicUpdateIntervalMillis` - defines interval for default updates. The default value is 1 week.
 - `expirationUpdateTreshold` - defines time window before the next certificate will expire. 
 In this time window `CertStore` will try to update the list of fingerprints more often than usual. 
@@ -109,26 +109,27 @@ Default value is 2 weeks before the next expiration.
 - `executorService` - defines `java.util.concurrent.ExecutorService` for running updates.
 If not defined updates run on a dedicated thread (not pooled).
 
-### Predefined Fingerprint
+### Predefined Fingerprints
 
-The `CertStoreConfiguration` may contain an optional data with predefined certificate fingerprint. 
+The `CertStoreConfiguration` may contain an optional data with predefined certificate fingerprints. 
 This technique can speed up the first application's startup when the database of fingerprints is empty. 
-You still need to [update](#updating-fingerprints) your application, once the fallback fingerprint expires.
+You still need to [update](#updating-fingerprints) your application, once the fallback fingerprints expire.
 
-To configure the property, you need to provide `GetFingerprintResponse.Entry` with a fallback certificate fingerprint. 
+To configure the property, you need to provide `GetFingerprintResponse` with a fallback certificate fingerprints. 
 The data should contain the same data as are usually received from the server, 
 except that `signature` property is not validated (but must be provided). For example:
 
 ```kotlin
-val fallbackData = GetFingerprintResponse.Entry(
+val fallbackEntry = GetFingerprintResponse.Entry(
                        name = "github.com",
                        fingerprint = fingerprintBytes,
-                       expires new Date(1591185600000),
+                       expires = Date(1591185600000),
                        ByteArray(0))
+val fallbackCertificates = GetFingerprintResponse(arrayOf(fallbackEntry))
 val configuration = CertStoreConfiguration.Builder(
                             serviceUrl = URL("https://..."),
                             publicKey= publicKey)
-                    .fallbackCertificateData(fallbackData)
+                    .fallbackCertificates(fallbackCertificates)
                     .build()
 val certStore = CertStore.powerAuthCertStore(configuration = configuration, appContext)
 ```
@@ -298,7 +299,7 @@ For example, this is how the configuration sequence may look like if you want to
 val certStoreConfiguration = CertStoreConfiguration.Builder(
                             serviceUrl = URL("https://..."),
                             publicKey= publicKey)
-                    .fallbackCertificateData(fallbackData)
+                    .fallbackCertificates(fallbackCertificates)
                     .build()
                     
 val powerAuthCertStore = CertStore.powerAuthCertStore(certStoreConfiguration, appContext)

--- a/library/src/androidTest/java/com/wultra/android/sslpinning/CertStoreValidateTest.kt
+++ b/library/src/androidTest/java/com/wultra/android/sslpinning/CertStoreValidateTest.kt
@@ -35,7 +35,7 @@ class CertStoreValidateTest : CommonTest() {
     fun validateWithFallback() {
         val fallbackFingerprints = GSON.fromJson(jsonData, GetFingerprintResponse::class.java)
         val config = CertStoreConfiguration.Builder(url, getPublicKeyBytes())
-                .fallbackCertificate(fallbackFingerprints.fingerprints[0])
+                .fallbackCertificates(fallbackFingerprints)
                 .build()
         val store = CertStore.powerAuthCertStore(config, appContext)
 

--- a/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
@@ -54,7 +54,7 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
     @Volatile
     private var cacheIsLoaded = false
     private var cachedData: CachedData? = null
-    private var fallbackCertificates = Array<CertificateInfo>()
+    private var fallbackCertificates = emptyArray<CertificateInfo>()
 
     private val validationObservers: MutableSet<ValidationObserver> = mutableSetOf()
     private val mainThreadHandler = Handler(Looper.getMainLooper())
@@ -155,8 +155,8 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
         secureDataStore.save(data = encodedData, key = instanceIdentifier)
     }
 
-    internal fun loadFallbackCertificates(): Array<CertificateInfo>? {
-        val fallbackEntries = configuration.fallbackCertificates?.fingerprints ?: return null
+    internal fun loadFallbackCertificates(): Array<CertificateInfo> {
+        val fallbackEntries = configuration.fallbackCertificates?.fingerprints ?: return emptyArray()
         return fallbackEntries.map { CertificateInfo(it) }.toTypedArray()
     }
 

--- a/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
@@ -54,7 +54,7 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
     @Volatile
     private var cacheIsLoaded = false
     private var cachedData: CachedData? = null
-    private var fallbackCertificates: Array<CertificateInfo>? = null
+    private var fallbackCertificates = Array<CertificateInfo>()
 
     private val validationObservers: MutableSet<ValidationObserver> = mutableSetOf()
     private val mainThreadHandler = Handler(Looper.getMainLooper())
@@ -106,11 +106,7 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
     @Synchronized
     internal fun getCertificates(): Array<CertificateInfo> {
         restoreCache()
-        var result = cachedData?.certificates ?: arrayOf()
-        fallbackCertificates?.let {
-            result = arrayOf(*result, *it)
-        }
-        return result
+        return cachedData?.let { it.certificates + fallbackCertificates } ?: fallbackCertificates
     }
 
     /**

--- a/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
@@ -386,6 +386,7 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
             }
             if (info.commonName == commonName) {
                 if (info.fingerprint.contentEquals(fingerprint)) {
+                    notifyValidationObservers(commonName, ValidationObserver::onValidationTrusted)
                     return ValidationResult.TRUSTED
                 }
                 matchAttempts += 1

--- a/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/CertStore.kt
@@ -54,7 +54,7 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
     @Volatile
     private var cacheIsLoaded = false
     private var cachedData: CachedData? = null
-    private var fallbackCertificate: CertificateInfo? = null
+    private var fallbackCertificates: Array<CertificateInfo>? = null
 
     private val validationObservers: MutableSet<ValidationObserver> = mutableSetOf()
     private val mainThreadHandler = Handler(Looper.getMainLooper())
@@ -107,8 +107,8 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
     internal fun getCertificates(): Array<CertificateInfo> {
         restoreCache()
         var result = cachedData?.certificates ?: arrayOf()
-        fallbackCertificate?.let {
-            result = arrayOf(*result, it)
+        fallbackCertificates?.let {
+            result = arrayOf(*result, *it)
         }
         return result
     }
@@ -137,7 +137,7 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
     private fun restoreCache() {
         if (!cacheIsLoaded) {
             cachedData = loadCachedData()
-            fallbackCertificate = loadFallbackCertificate()
+            fallbackCertificates = loadFallbackCertificates()
             cacheIsLoaded = true
         }
     }
@@ -159,9 +159,9 @@ class CertStore internal constructor(private val configuration: CertStoreConfigu
         secureDataStore.save(data = encodedData, key = instanceIdentifier)
     }
 
-    internal fun loadFallbackCertificate(): CertificateInfo? {
-        val fallbackEntry = configuration.fallbackCertificate ?: return null
-        return CertificateInfo(fallbackEntry)
+    internal fun loadFallbackCertificates(): Array<CertificateInfo>? {
+        val fallbackEntries = configuration.fallbackCertificates?.fingerprints ?: return null
+        return fallbackEntries.map { CertificateInfo(it) }.toTypedArray()
     }
 
     /*** UPDATE ***/

--- a/library/src/main/java/com/wultra/android/sslpinning/CertStoreConfiguration.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/CertStoreConfiguration.kt
@@ -192,7 +192,7 @@ class CertStoreConfiguration(
          * Fallback certificate fingerprint.
          * Useful for situations when no fingerprints has been loaded from the server yet.
          */
-        @Deprecated("Use fallbackCertificates instead. This option is ignored when fallbackCertificates method is used.")
+        @Deprecated("Use fallbackCertificates instead. This method will be removed in the future.")
         fun fallbackCertificate(fallbackCertificate: GetFingerprintResponse.Entry?) = apply {
             this.fallbackCertificate = fallbackCertificate
         }

--- a/library/src/main/java/com/wultra/android/sslpinning/ValidationObserver.kt
+++ b/library/src/main/java/com/wultra/android/sslpinning/ValidationObserver.kt
@@ -31,6 +31,14 @@ import android.support.annotation.MainThread
 interface ValidationObserver {
 
     /**
+     * Called when a validation for a common name is deemed [ValidationResult.TRUSTED].
+     *
+     * @param commonName The common name that was validated with result [ValidationResult.TRUSTED].
+     */
+    @MainThread
+    fun onValidationTrusted(commonName: String)
+
+    /**
      * Called when a validation for a common name is deemed [ValidationResult.UNTRUSTED].
      *
      * @param commonName The common name that was validated with result [ValidationResult.UNTRUSTED].

--- a/library/src/test/java/com/wultra/android/sslpinning/CertStoreConfigurationTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/CertStoreConfigurationTest.java
@@ -24,6 +24,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -52,7 +53,7 @@ public class CertStoreConfigurationTest extends CommonJavaTest {
     @Test
     public void testConfiguration() throws Exception {
         CertStoreConfiguration config = configuration(new Date());
-        assertNull(config.getFallbackCertificate());
+        assertNull(config.getFallbackCertificates());
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
         TestUtils.assignHandler(store, handler);
 
@@ -65,7 +66,7 @@ public class CertStoreConfigurationTest extends CommonJavaTest {
     @Test
     public void testConfigurationWithFallbackCertificate() throws Exception {
         CertStoreConfiguration config = configurationWithFallback(null, null);
-        assertNotNull(config.getFallbackCertificate());
+        assertNotNull(config.getFallbackCertificates());
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
         TestUtils.assignHandler(store, handler);
 
@@ -79,7 +80,7 @@ public class CertStoreConfigurationTest extends CommonJavaTest {
     public void testConfigurationWithFallbackCertificateExpired() throws Exception {
         Date expired = new Date(new Date().getTime() - TimeUnit.SECONDS.toMillis(1));
         CertStoreConfiguration config = configurationWithFallback(expired, null);
-        assertNotNull(config.getFallbackCertificate());
+        assertNotNull(config.getFallbackCertificates());
         CertStore store = new CertStore(config, cryptoProvider, secureDataStore);
         TestUtils.assignHandler(store, handler);
 
@@ -144,8 +145,8 @@ public class CertStoreConfigurationTest extends CommonJavaTest {
         byte[] signature = new byte[64];
         Arrays.fill(signature, (byte)0xfe);
 
-        GetFingerprintResponse.Entry fallbackData = new GetFingerprintResponse.Entry(
-                "api.fallback.org", fingerprint, expiration, signature);
+        GetFingerprintResponse.Entry[] fallbackList = new GetFingerprintResponse.Entry[] { new GetFingerprintResponse.Entry("api.fallback.org", fingerprint, expiration, signature) };
+        GetFingerprintResponse fallbackData = new GetFingerprintResponse(fallbackList);
 
         return TestUtils.getCertStoreConfiguration(expiration, expectedCommonNames, serviceUrl, publicKeyBytes, fallbackData);
     }

--- a/library/src/test/java/com/wultra/android/sslpinning/CertStoreValidationTest.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/CertStoreValidationTest.java
@@ -50,11 +50,12 @@ public class CertStoreValidationTest extends CommonJavaTest {
         String fingerprintBase64 = "MRFQDEpmASza4zPsP8ocnd5FyVREDn7kE3Fr/zZjwHQ=";
         byte[] fingerprintBytes = Base64.getDecoder().decode(fingerprintBase64);
 
-        GetFingerprintResponse.Entry fallback = new GetFingerprintResponse.Entry(
+        GetFingerprintResponse.Entry fallbackEntry = new GetFingerprintResponse.Entry(
                 "github.com",
                 fingerprintBytes,
                 new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1)),
                 signatureBytes);
+        GetFingerprintResponse fallback = new GetFingerprintResponse(new GetFingerprintResponse.Entry[] {fallbackEntry});
 
         CertStoreConfiguration config = TestUtils.getCertStoreConfiguration(
                 new Date(),

--- a/library/src/test/java/com/wultra/android/sslpinning/TestUtils.java
+++ b/library/src/test/java/com/wultra/android/sslpinning/TestUtils.java
@@ -56,12 +56,12 @@ public class TestUtils {
         }
     }
 
-    public static CertStoreConfiguration getCertStoreConfiguration(Date expiration, String[] expectedCommonNames, URL serviceUrl, byte[] publicKey, GetFingerprintResponse.Entry fallback) {
+    public static CertStoreConfiguration getCertStoreConfiguration(Date expiration, String[] expectedCommonNames, URL serviceUrl, byte[] publicKey, GetFingerprintResponse fallback) {
         CertStoreConfiguration.Builder builder = new CertStoreConfiguration.Builder(
                 serviceUrl, publicKey)
                 .identifier(null)
                 .expectedCommonNames(expectedCommonNames)
-                .fallbackCertificate(fallback);
+                .fallbackCertificates(fallback);
         return builder.build();
     }
 

--- a/library/src/test/java/com/wultra/android/sslpinning/ValidationObserverTest.kt
+++ b/library/src/test/java/com/wultra/android/sslpinning/ValidationObserverTest.kt
@@ -58,6 +58,7 @@ class ValidationObserverTest : CommonKotlinTest() {
         assertEquals(ValidationResult.EMPTY, result)
         verify(observer, times(0)).onValidationUntrusted(anyString())
         verify(observer, times(1)).onValidationEmpty(anyString())
+        verify(observer, times(0)).onValidationTrusted(anyString())
         store.removeValidationObserver(observer)
 
         TestUtils.updateAndCheck(store, UpdateMode.FORCED, UpdateResult.OK)
@@ -68,6 +69,7 @@ class ValidationObserverTest : CommonKotlinTest() {
         assertEquals(ValidationResult.TRUSTED, result2)
         verify(observer, times(0)).onValidationUntrusted(anyString())
         verify(observer, times(0)).onValidationEmpty(anyString())
+        verify(observer, times(1)).onValidationTrusted(anyString())
         store.removeAllValidationObservers()
 
         observer = mock(ValidationObserver::class.java)
@@ -76,6 +78,7 @@ class ValidationObserverTest : CommonKotlinTest() {
         assertEquals(ValidationResult.UNTRUSTED, result3)
         verify(observer, times(1)).onValidationUntrusted(anyString())
         verify(observer, times(0)).onValidationEmpty(anyString())
+        verify(observer, times(0)).onValidationTrusted(anyString())
         store.removeAllValidationObservers()
     }
 }


### PR DESCRIPTION
2 things in this PR in separate commits:

**1. Added method for the trusted result to global observer**
- https://github.com/wultra/ssl-pinning-android/commit/702e9019b43e888c4b031422d1815da7fca89dee
- To be able to observe and log if everything is OK from the app

**2. Added support for multiple fallback certs**
- https://github.com/wultra/ssl-pinning-android/commit/f726c0daeb63d5437e8807c5829f9ea2a564c14c
- This is needed in cases the app is communicating with several backends and wants to have 1 certstore for the whole app.
- I deprecated the old `fallbackCertificate` builder method and introduced a new one `fallbackCertificates`